### PR TITLE
feat: limit the number of maximum shopping-list-ingredients to 50 and…

### DIFF
--- a/apps/api/src/utils/wrapWithTsRestError/index.ts
+++ b/apps/api/src/utils/wrapWithTsRestError/index.ts
@@ -1,3 +1,4 @@
+import { ErrorCodes } from '@jcmono/api-contract';
 import type { AppRoute } from '@ts-rest/core';
 import { TsRestException } from '@ts-rest/nest';
 import handlePrismaErrorCode from '../handlePrismaErrorCode';
@@ -15,9 +16,14 @@ const wrapWithTsRestError = async <T>(
       throw new TsRestException(contractEndpoint, prismaError);
     }
 
+    const isNativeError = error instanceof Error;
+
     throw new TsRestException(contractEndpoint, {
       status: 500,
-      body: { message: 'Internal server error' },
+      body: {
+        message: isNativeError ? error.message : 'Internal server error',
+        code: isNativeError ? ErrorCodes.BASIC_ERROR : ErrorCodes.UNKNOWN_ERROR,
+      },
     });
   }
 };

--- a/apps/food-planner-client/src/components/ShoppingList/components/ItemCountBadge/index.tsx
+++ b/apps/food-planner-client/src/components/ShoppingList/components/ItemCountBadge/index.tsx
@@ -1,0 +1,34 @@
+import { MAXIMUM_SAVED_SHOPPING_LIST_ITEMS } from "@jcmono/api-contract";
+
+import type { TItemCountBadgeProps } from "./types";
+
+function ItemCountBadge({ count }: TItemCountBadgeProps) {
+  const getBadgeStyles = (): string => {
+    const ratio = count / MAXIMUM_SAVED_SHOPPING_LIST_ITEMS;
+    if (ratio >= 0.9)
+      return "bg-red-100 text-red-700 border border-red-200";
+    if (ratio >= 0.7)
+      return "bg-yellow-100 text-yellow-700 border border-yellow-200";
+    if (ratio >= 0.5)
+      return "bg-blue-100 text-blue-700 border border-blue-200";
+    return "bg-green-100 text-green-700 border border-green-200";
+  };
+
+  const badgeClasses = `px-3 rounded-full text-sm font-medium mr-4 transition-colors ${getBadgeStyles()}`;
+
+  return (
+    <div className={badgeClasses}>
+      <span className="flex items-center gap-1 h-full">
+        <span>
+          {count}
+          {" "}
+          /
+          {" "}
+          {MAXIMUM_SAVED_SHOPPING_LIST_ITEMS}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export default ItemCountBadge;

--- a/apps/food-planner-client/src/components/ShoppingList/components/ItemCountBadge/types.ts
+++ b/apps/food-planner-client/src/components/ShoppingList/components/ItemCountBadge/types.ts
@@ -1,0 +1,3 @@
+export type TItemCountBadgeProps = {
+  count: number;
+};

--- a/apps/food-planner-client/src/components/ShoppingList/index.tsx
+++ b/apps/food-planner-client/src/components/ShoppingList/index.tsx
@@ -7,6 +7,7 @@ import AddShoppingListItemForm from "@forms/AddShoppingListItemForm";
 
 import HeaderWithIcon from "../HeaderWithIcon";
 
+import ItemCountBadge from "./components/ItemCountBadge";
 import ShoppingListItem from "./components/ShoppingListItem";
 
 function ShoppingList() {
@@ -14,17 +15,24 @@ function ShoppingList() {
 
   return (
     <div className="max-h-full overflow-hidden flex flex-col py-4">
-      <HeaderWithIcon icon={ShoppingBag} title="Shopping List" />
-      <div className="">
-        <AddShoppingListItemForm />
+      <div className="flex justify-between align-center">
+        <HeaderWithIcon icon={ShoppingBag} title="Shopping List" />
+        {data && (
+          <ItemCountBadge count={data?.body.length} />
+        )}
       </div>
+
+      <AddShoppingListItemForm />
 
       {data && !data.body.length && (
         <div className="text-center py-12">
           <ShoppingCart className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
-          <h2 className="text-xl font-medium mb-2">Your shopping list is empty</h2>
+          <h2 className="text-xl font-medium mb-2">
+            Your shopping list is empty
+          </h2>
           <p className="text-muted-foreground max-w-md mx-auto mb-6">
-            Add items manually using the form above or generate a list from your meal schedule.
+            Add items manually using the form above or generate a list from your
+            meal schedule.
           </p>
         </div>
       )}
@@ -33,13 +41,14 @@ function ShoppingList() {
         <Card className="my-4 overflow-y-auto max-h-[calc(100vh-48px)]">
           <CardContent className="p-0">
             <ul className="divide-y">
-              {data.body.map(item => <ShoppingListItem key={item.id} item={item} />)}
+              {data.body.map(item => (
+                <ShoppingListItem key={item.id} item={item} />
+              ))}
             </ul>
           </CardContent>
         </Card>
       )}
     </div>
-
   );
 }
 

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -19,7 +19,7 @@ import {
   ShoppingListIngredientSchema,
   ShoppingListIngredientUpdateSchema,
   StringToNumberSchema,
-  UserSchema,
+  UserSchema
 } from "./schemas/index";
 import {
   ScheduleMealsCreateSchema,
@@ -192,10 +192,10 @@ export const contract = c.router(
         path: "/shoppingListIngredient/recipe/:id",
         pathParams: z.object({ id: StringToNumberSchema }),
         body: null,
-        responses:{
-            201:z.array(ShoppingListIngredientSchema),
-            404: NotFoundSchema,
-        }
+        responses: {
+          201: z.array(ShoppingListIngredientSchema),
+          404: NotFoundSchema,
+        },
       },
       update: {
         method: "PUT",

--- a/packages/api-contract/src/schemas/shoppingListIngredients.ts
+++ b/packages/api-contract/src/schemas/shoppingListIngredients.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { QuantityUnit } from "./ingredients";
 import { BooleanQuerySchema } from "./utils";
 
+export const MAXIMUM_SAVED_SHOPPING_LIST_ITEMS = 50;
+
 export const ShoppingListIngredientSchema = z.object({
   id: z.number(),
   createdAt: z.date(),

--- a/packages/api-contract/src/schemas/utils.ts
+++ b/packages/api-contract/src/schemas/utils.ts
@@ -24,3 +24,13 @@ export const BooleanQuerySchema = z.preprocess(
 
 export const GetQueryFilter = z.enum(["USER", "GLOBAL", "ALL"]);
 export type TGetQueryFilter = z.infer<typeof GetQueryFilter>;
+
+export enum ErrorCodes {
+  UNKNOWN_ERROR = "UNKNOWN_ERROR",
+  BASIC_ERROR = "BASIC_ERROR",
+}
+
+export const ErrorResponseSchema = z.object({
+  code: z.enum([ErrorCodes.UNKNOWN_ERROR, ErrorCodes.BASIC_ERROR]),
+  message: z.string(),
+});


### PR DESCRIPTION
- limit the maximum number of active shopping list ingredients per user to 50
- add a badge with current number of shopping list ingredients